### PR TITLE
Add identifier, relation and properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `php-opds` will be documented in this file.
 
+## v1.x.x - 2023-09-13
+
+- Update `OpdsJsonEngine` to use these options for OPDS 2.0 output - @todo OPDS 1.2 was not adapted in this PR
+- Add `properties` option for `OpdsEntryNavigation` to include extra properties (like numberOfItems for facets)
+- Add `relation` option for `OpdsEntryNavigation` to specify the relation to use (instead of `current`)
+- Add `identifier` option for `OpdsEntryBook` to specify the actual identifier to use (instead of `urn:isbn:...`)
+
 ## v1.0.1 - 2023-09-07
 
 - Add `useAutoPagination` option for `OpdsConfig` to enable/disable auto pagination (works only for `OpdsEntryBook`)

--- a/src/Engine/OpdsJsonEngine.php
+++ b/src/Engine/OpdsJsonEngine.php
@@ -134,10 +134,15 @@ class OpdsJsonEngine extends OpdsEngine
             $summary = (string) json_decode($summary, true, 512, JSON_THROW_ON_ERROR);
         }
 
+        $identifier = $entry->getIdentifier();
+        if (empty($identifier)) {
+            $identifier = "urn:isbn:{$entry->getIsbn()}";
+        }
+
         return [
             'metadata' => [
                 '@type' => 'http://schema.org/EBook',
-                'identifier' => "urn:isbn:{$entry->getIsbn()}",
+                'identifier' => $identifier,
                 'title' => $entry->getTitle(),
                 'author' => $mainAuthor,
                 'translator' => $entry->getTranslator(),

--- a/src/Engine/OpdsJsonEngine.php
+++ b/src/Engine/OpdsJsonEngine.php
@@ -93,7 +93,7 @@ class OpdsJsonEngine extends OpdsEngine
             'href' => $this->route($entry->getRoute()),
             'title' => $entry->getTitle(),
             'type' => 'application/opds+json',
-            'rel' => 'current',
+            'rel' => $entry->getRelation() ?? 'current',
         ];
     }
 

--- a/src/Engine/OpdsJsonEngine.php
+++ b/src/Engine/OpdsJsonEngine.php
@@ -89,6 +89,18 @@ class OpdsJsonEngine extends OpdsEngine
 
     public function addNavigationEntry(OpdsEntryNavigation $entry): array
     {
+        $properties = $entry->getProperties();
+
+        if ($properties) {
+            return [
+                'href' => $this->route($entry->getRoute()),
+                'title' => $entry->getTitle(),
+                'type' => 'application/opds+json',
+                'rel' => $entry->getRelation() ?? 'current',
+                'properties' => $properties,
+            ];
+        }
+
         return [
             'href' => $this->route($entry->getRoute()),
             'title' => $entry->getTitle(),

--- a/src/Entries/OpdsEntryBook.php
+++ b/src/Entries/OpdsEntryBook.php
@@ -27,6 +27,7 @@ class OpdsEntryBook extends OpdsEntryNavigation
         protected ?string $serie = null,
         protected ?string $language = null,
         protected ?string $isbn = null,
+        protected ?string $identifier = null,
         protected ?string $translator = null,
         protected ?string $publisher = null,
     ) {
@@ -110,6 +111,13 @@ class OpdsEntryBook extends OpdsEntryNavigation
         return $this;
     }
 
+    public function identifier(string $identifier): self
+    {
+        $this->identifier = $identifier;
+
+        return $this;
+    }
+
     public function translator(string $translator): self
     {
         $this->translator = $translator;
@@ -175,6 +183,11 @@ class OpdsEntryBook extends OpdsEntryNavigation
         return $this->isbn;
     }
 
+    public function getIdentifier(): ?string
+    {
+        return $this->identifier;
+    }
+
     public function getTranslator(): ?string
     {
         return $this->translator;
@@ -197,6 +210,7 @@ class OpdsEntryBook extends OpdsEntryNavigation
             'serie' => $this->getSerie(),
             'language' => $this->getLanguage(),
             'isbn' => $this->getIsbn(),
+            'identifier' => $this->getIdentifier(),
             'translator' => $this->getTranslator(),
             'publisher' => $this->getPublisher(),
         ]);

--- a/src/Entries/OpdsEntryNavigation.php
+++ b/src/Entries/OpdsEntryNavigation.php
@@ -14,6 +14,7 @@ class OpdsEntryNavigation extends OpdsEntry
         protected ?string $content = null,
         protected ?string $media = null,
         protected ?string $relation = null,
+        protected ?array $properties = null,
         protected DateTime|string|null $updated = null,
     ) {
         $this->summary = OpdsEntryNavigation::handleContent($this->summary);
@@ -69,6 +70,13 @@ class OpdsEntryNavigation extends OpdsEntry
         return $this;
     }
 
+    public function properties(array $properties): self
+    {
+        $this->properties = $properties;
+
+        return $this;
+    }
+
     public function updated(DateTime|string|null $updated): self
     {
         $this->updated = $updated;
@@ -111,6 +119,11 @@ class OpdsEntryNavigation extends OpdsEntry
         return $this->relation;
     }
 
+    public function getProperties(): ?array
+    {
+        return $this->properties;
+    }
+
     public function getUpdated(): DateTime|string|null
     {
         return $this->updated;
@@ -125,6 +138,7 @@ class OpdsEntryNavigation extends OpdsEntry
             'summary' => $this->getSummary(),
             'media' => $this->getMedia(),
             'relation' => $this->getRelation(),
+            'properties' => $this->getProperties(),
             'updated' => $this->getUpdated(),
         ];
     }

--- a/src/Entries/OpdsEntryNavigation.php
+++ b/src/Entries/OpdsEntryNavigation.php
@@ -13,6 +13,7 @@ class OpdsEntryNavigation extends OpdsEntry
         protected ?string $summary = null,
         protected ?string $content = null,
         protected ?string $media = null,
+        protected ?string $relation = null,
         protected DateTime|string|null $updated = null,
     ) {
         $this->summary = OpdsEntryNavigation::handleContent($this->summary);
@@ -61,6 +62,13 @@ class OpdsEntryNavigation extends OpdsEntry
         return $this;
     }
 
+    public function relation(string $relation): self
+    {
+        $this->relation = $relation;
+
+        return $this;
+    }
+
     public function updated(DateTime|string|null $updated): self
     {
         $this->updated = $updated;
@@ -98,6 +106,11 @@ class OpdsEntryNavigation extends OpdsEntry
         return $this->media;
     }
 
+    public function getRelation(): ?string
+    {
+        return $this->relation;
+    }
+
     public function getUpdated(): DateTime|string|null
     {
         return $this->updated;
@@ -111,6 +124,7 @@ class OpdsEntryNavigation extends OpdsEntry
             'route' => $this->getRoute(),
             'summary' => $this->getSummary(),
             'media' => $this->getMedia(),
+            'relation' => $this->getRelation(),
             'updated' => $this->getUpdated(),
         ];
     }


### PR DESCRIPTION
I did a first test with php-opds 1.0.1 in combination with COPS, and it's looking good so far to generate OPDS 2.0 feeds.

Here are a few changes I made to php-opds that were useful:
- Update OpdsJsonEngine to use these options for OPDS 2.0 output - @todo OPDS 1.2 was not adapted in this PR
- Add properties option for OpdsEntryNavigation to include extra properties (like numberOfItems for facets)
- Add relation option for OpdsEntryNavigation to specify the relation to use (instead of current)
- Add identifier option for OpdsEntryBook to specify the actual identifier to use (instead of urn:isbn:...)

Let me know what you think...
