### PR TITLE
Paging information for pre-paginated feeds

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -22,6 +22,6 @@ jobs:
         uses: aglipanci/laravel-pint-action@2.3.0
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Fix styling

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -24,7 +24,7 @@ jobs:
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: main
           commit_message: Update CHANGELOG

--- a/src/Engine/OpdsJsonEngine.php
+++ b/src/Engine/OpdsJsonEngine.php
@@ -36,8 +36,10 @@ class OpdsJsonEngine extends OpdsEngine
                 'icon' => $this->opds->getConfig()->getIconUrl(),
             ],
             'links' => [
-                $this->addJsonLink(rel: 'self', href: OpdsEngine::getCurrentUrl()),
-                $this->addJsonLink(rel: 'start', href: $this->route($this->opds->getConfig()->getStartUrl())),
+                // use self link from opds->getUrl() in case it's overridden - default value is set to current url in Opds::make()
+                $this->addJsonLink(rel: 'self', href: $this->route($this->opds->getUrl())),
+                // use start link if defined in OpdsConfig - default value is null here
+                $this->addJsonLink(rel: 'start', href: $this->route($this->opds->getConfig()->getStartUrl() ?? $this->opds->getUrl())),
             ],
         ];
 

--- a/src/Engine/OpdsJsonEngine.php
+++ b/src/Engine/OpdsJsonEngine.php
@@ -67,7 +67,11 @@ class OpdsJsonEngine extends OpdsEngine
         }
 
         $feeds = $this->opds->getFeeds();
-        $this->paginate($this->contents, $feeds);
+        if ($this->opds->hasPaging()) {
+            $this->addPaging($this->opds->getPaging());
+        } else {
+            $this->paginate($this->contents, $feeds);
+        }
 
         foreach ($feeds as $feed) {
             if ($feed instanceof OpdsEntryBook) {
@@ -170,5 +174,57 @@ class OpdsJsonEngine extends OpdsEngine
                 // ['href' => 'http://example.org/cover.svg', 'type' => 'image/svg+xml'],
             ],
         ];
+    }
+
+    /**
+     * Add paging information to contents for pre-paginated feeds
+     * @param array<string, mixed> $paging paging information
+     * @todo re-use with OpdsPaginator::json() + add equivalent for xml engine
+     */
+    public function addPaging($paging): void
+    {
+        $this->contents['metadata'] = [
+            ...$this->contents['metadata'],
+            'numberOfItems' => $paging['total'],
+            'itemsPerPage' => $paging['perPage'],
+            'currentPage' => $paging['page'],
+        ];
+
+        $this->contents['links'] = [
+            OpdsEngine::addJsonLink(
+                rel: 'self',
+                href: $this->route($this->opds->getUrl()),
+            ),
+        ];
+
+        // @todo combine rel: ["first", "previous"] if equal? - see basic example https://drafts.opds.io/opds-2.0#3-pagination
+        if ($paging['first']) {
+            $this->contents['links'][] = OpdsEngine::addJsonLink(
+                rel: 'first',
+                href: $this->route($paging['first']),
+            );
+        }
+
+        if ($paging['previous']) {
+            $this->contents['links'][] = OpdsEngine::addJsonLink(
+                rel: 'previous',
+                href: $this->route($paging['previous']),
+            );
+        }
+
+        // @todo combine rel: ["next", "last"] if equal?
+        if ($paging['next']) {
+            $this->contents['links'][] = OpdsEngine::addJsonLink(
+                rel: 'next',
+                href: $this->route($paging['next']),
+            );
+        }
+
+        if ($paging['last']) {
+            $this->contents['links'][] = OpdsEngine::addJsonLink(
+                rel: 'last',
+                href: $this->route($paging['last']),
+            );
+        }
     }
 }

--- a/src/Opds.php
+++ b/src/Opds.php
@@ -13,6 +13,9 @@ use Kiwilan\Opds\Enums\OpdsVersionEnum;
 
 class Opds
 {
+    /** @var array<string, mixed> */
+    protected array $paging = [];
+
     /**
      * @param  array<string, mixed>  $urlParts
      * @param  array<string, mixed>  $query
@@ -92,6 +95,30 @@ class Opds
     public function isSearch(): self
     {
         $this->isSearch = true;
+
+        return $this;
+    }
+
+    /**
+     * Paging information for pre-paginated feeds
+     * @param int $page current page number (default 1)
+     * @param int $total total number of items (default 0)
+     * @param ?string $first link to first page (default null)
+     * @param ?string $last link to last page (default null)
+     * @param ?string $previous link to previous page (default null)
+     * @param ?string $next link to next page (default null)
+     */
+    public function paging(int $page = 1, int $total = 0, ?string $first = null, ?string $last = null, ?string $previous = null, ?string $next = null): self
+    {
+        $this->paging = [
+            'page' => $page,
+            'total' => $total,
+            'first' => $first,
+            'last' => $last,
+            'previous' => $previous,
+            'next' => $next,
+        ];
+        $this->paging['perPage'] = $this->getConfig()->getMaxItemsPerPage();
 
         return $this;
     }
@@ -240,6 +267,15 @@ class Opds
     public function getFeeds(): array
     {
         return $this->feeds;
+    }
+
+    /**
+     * Get paging information for pre-paginated feeds
+     * @return array<string, mixed>
+     */
+    public function getPaging(): array
+    {
+        return $this->paging;
     }
 
     /**

--- a/src/Opds.php
+++ b/src/Opds.php
@@ -279,6 +279,17 @@ class Opds
     }
 
     /**
+     * Check if Opds has paging information
+     */
+    public function hasPaging(): bool
+    {
+        if (!empty($this->paging) && !empty($this->paging['total'])) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Know if current page is search page.
      */
     public function checkIfSearch(): bool

--- a/tests/OpdsPagingInfoTest.php
+++ b/tests/OpdsPagingInfoTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Kiwilan\Opds\Opds;
+
+it('can use paging information for json', function () {
+    $feeds = manyFeeds();
+    $total = count($feeds);
+    $feeds = array_slice(manyFeeds(), 33, 32);
+    $page = 2;
+    $opds = Opds::make(getConfig()->forceJson())
+        // current app url
+        ->url('http://localhost:8080/opds?u=2')
+        // pre-paginated feed
+        ->feeds($feeds)
+        // paging information with some links
+        ->paging(page: $page, total: $total, first: 'http://localhost:8080/opds?f=1', last: 'http://localhost:8080/opds?l=42', previous: 'http://localhost:8080/opds?p=1', next: 'http://localhost:8080/opds?n=3')
+        ->get();
+
+    $response = json_decode($opds->getResponse()->getContents(), true);
+
+    $pagination = [];
+    foreach ($response['links'] as $item) {
+        $pagination[$item['rel']] = $item;
+    }
+
+    expect(count($pagination))->toBe(5);
+    expect($pagination['self']['href'])->toBe('http://localhost:8080/opds?u=2');
+    expect($pagination['first']['href'])->toBe('http://localhost:8080/opds?f=1');
+    expect($pagination['last']['href'])->toBe('http://localhost:8080/opds?l=42');
+    expect($pagination['next']['href'])->toBe('http://localhost:8080/opds?n=3');
+    expect($pagination['previous']['href'])->toBe('http://localhost:8080/opds?p=1');
+
+    expect($response['publications'])->toBeArray();
+    expect(count($response['publications']))->toBe(32);
+});


### PR DESCRIPTION
This gives a basic example of how paging information could be added for pre-paginated feeds

Practical use-case is discussed in issue #38 where feeds are already pre-paginated by the application, and the paging information is prepared up-front (total, page, first link, last link, ...).

See for example https://github.com/mikespub-org/seblucas-cops/blob/main/lib/Output/KiwilanOPDS.php#L216

```
        $url = $request->getCurrentUrl(static::$endpoint);
        if ($page->isPaginated()) {
            // ... prepare $first, $last, ... links
            $opds = Opds::make($this->getOpdsConfig())
            ->title($title)
            ->url($url)
            ->feeds($feeds)
            ->paging(page: $page->n, total: $page->totalNumber, first: $first, last: $last, previous: $previous, next: $next)
            ->get();
        } else {
            // ...
        }
        return $opds->getResponse();
```

Note: it's not meant to be complete with tests etc., and it completely by-passes/ignores the current paginator. Use as inspiration or stepping stone for your own further development :-)
