### PR TITLE
v2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-opds",
     "description": "PHP package to create OPDS feed for eBooks.",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "keywords": [
         "php",
         "ebook",


### PR DESCRIPTION
## Breaking changes

-   Add `OpdsPaginate::class` based on [https://github.com/kiwilan/php-opds/pull/40](https://github.com/kiwilan/php-opds/pull/40) from @mikespub to handle manual pagination for issue #38
-   `Opds` method `send()` have now a new parameter `bool $exit = false` to control if the script should exit after sending the response to replace `bool $mock = false` parameter. By default, `send()` will not exit the script.
-   Merge paginator with `paginate()` method, if you not set any parameter, it will generate pagination, if you set `OpdsPaginate` object, it will generate pagination based on it
-   Remove `usePagination` and `useAutoPagination` from `OpdsConfig` class, now you can use `paginate()` method to handle pagination

## Misc

-   `OpdsConfig::class` can have nullable `updated` attribute
