### PR TITLE
multi-byte safe substr() for OPDS summary

### DIFF
--- a/src/Entries/OpdsEntryNavigation.php
+++ b/src/Entries/OpdsEntryNavigation.php
@@ -143,13 +143,13 @@ class OpdsEntryNavigation extends OpdsEntry
         ];
     }
 
-    public static function handleContent(?string $content, int $length = 200, bool $stripTags = true): string
+    public static function handleContent(?string $content, int $length = 200, bool $stripTags = true, ?string $encoding = null): string
     {
         if (! $content) {
             return '';
         }
 
-        $content = strlen($content) > $length ? substr($content, 0, $length).'...' : $content;
+        $content = mb_strlen($content, $encoding) > $length ? mb_substr($content, 0, $length, $encoding).'...' : $content;
 
         if ($stripTags) {
             $content = strip_tags($content);


### PR DESCRIPTION
When a book description contains UTF-8 characters (e.g. Chinese description of Sun Tzu's The Art of War), truncating the content for the summary with substr() may cut it off in mid-character, which results in description = false in the OPDS feed  when going through the json_encode(...), json_decode(...) sequence in OpdsJsonEngine::addBookEntry()

Example Content:
```
<div>
<p>“前孙子者，孙子不遗；后孙子者，不遗孙子”。《孙子兵法》又称《孙武兵法》、《孙子兵书》等，是中国古典军事文化遗产中的璀璨瑰宝，是世界三大兵书之一。全书共十三篇，虽然只有五千余言，但内容包罗万象、博大精深，涉及到战争规律、哲理、谋略、政治、经济、外交、天文、地理等各方面内容，堪称古代兵学理论的宝库和集大成者，在世界广为传播，美国西点军校和哈佛商学院高级管理将其作为人才培训的必读教材。</p></div>
```

Summary with substr():
```
“前孙子者，孙子不遗；后孙子者，不遗孙子”。《孙子兵法》又称《孙武兵法》、《孙子兵书》等，是中国古典军事文化遗产中的璀璨瑰宝，是世界三大兵书之一。全书共十三篇，虽然只有五千余言，但内容包罗万象、博大精深，涉及到战争规律、哲理、谋略、政治、经济、外交、天文、地理等各方面内容，堪称古代兵学理论的宝库和集大成者，在世界广为传播，美�...
```
This is invalid UTF-8, which results in $summary = false in OpdsJsonEngine::addBookEntry()

Summary with mb_substr():
```
“前孙子者，孙子不遗；后孙子者，不遗孙子”。《孙子兵法》又称《孙武兵法》、《孙子兵书》等，是中国古典军事文化遗产中的璀璨瑰宝，是世界三大兵书之一。全书共十三篇，虽然只有五千余言，但内容包罗万象、博大精深，涉及到战争规律、哲理、谋略、政治、经济、外交、天文、地理等各方面内容，堪称古代兵学理论的宝库和集大成者，在世界广为传播，美国西点军校和哈佛商学院高级管理将其作为人才培训的必读教材...
```
This is valid UTF-8, which works correctly in OpdsJsonEngine::addBookEntry()
