### PR TITLE
v2.0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "kiwilan/php-opds",
   "description": "PHP package to create OPDS feed for eBooks.",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "keywords": [
     "php",
     "ebook",

--- a/src/Engine/OpdsJsonEngine.php
+++ b/src/Engine/OpdsJsonEngine.php
@@ -57,7 +57,7 @@ class OpdsJsonEngine extends OpdsEngine
             ];
         }
 
-        if ($this->opds->getConfig()->getStartUrl() && ! $this->opds->getConfig()->isForceJson()) {
+        if ($this->opds->getConfig()->getStartUrl() && ! $this->opds->getConfig()->isUseForceJson()) {
             $this->contents['links'][] = $this->addJsonLink(
                 rel: 'alternate',
                 href: $this->getVersionUrl(OpdsVersionEnum::v1Dot2),

--- a/src/Opds.php
+++ b/src/Opds.php
@@ -48,7 +48,7 @@ class Opds
         $self->url = OpdsEngine::getCurrentUrl();
         $self->parseUrl();
 
-        if ($config->isForceJson()) {
+        if ($config->isUseForceJson()) {
             $self->version = OpdsVersionEnum::v2Dot0;
         }
 
@@ -125,7 +125,7 @@ class Opds
             $this->version = $this->queryVersion;
         }
 
-        if ($this->config->isForceJson()) {
+        if ($this->config->isUseForceJson()) {
             $this->version = OpdsVersionEnum::v2Dot0;
         }
 
@@ -145,6 +145,10 @@ class Opds
             $this->paginator = $this->engine->getPaginator();
         }
         $this->response = OpdsResponse::make($this->engine->__toString(), $this->output, 200);
+
+        if ($this->config->isUseForceExit()) {
+            $this->response->forceExit();
+        }
 
         return $this;
     }

--- a/src/OpdsConfig.php
+++ b/src/OpdsConfig.php
@@ -21,6 +21,7 @@ class OpdsConfig
      * @param  ?DateTime  $updated  Updated date, for example: `new DateTime()`.
      * @param  int  $maxItemsPerPage  Maximum items per page, default is `32`.
      * @param  bool  $forceJson  Force OPDS version 2.0 as default, default is `false`.
+     * @param  bool  $forceExit  Force send response as default, default is `false`.
      */
     public function __construct(
         protected ?string $name = 'opds',
@@ -34,6 +35,7 @@ class OpdsConfig
         protected ?DateTime $updated = null,
         protected int $maxItemsPerPage = 16,
         protected bool $forceJson = false,
+        protected bool $forceExit = false,
     ) {
         if (! $this->updated) {
             $this->updated = new DateTime();
@@ -90,9 +92,14 @@ class OpdsConfig
         return $this->maxItemsPerPage;
     }
 
-    public function isForceJson(): bool
+    public function isUseForceJson(): bool
     {
         return $this->forceJson;
+    }
+
+    public function isUseForceExit(): bool
+    {
+        return $this->forceExit;
     }
 
     public function setName(string $name): self
@@ -172,6 +179,13 @@ class OpdsConfig
     public function forceJson(): self
     {
         $this->forceJson = true;
+
+        return $this;
+    }
+
+    public function forceExit(): self
+    {
+        $this->forceExit = true;
 
         return $this;
     }

--- a/src/OpdsResponse.php
+++ b/src/OpdsResponse.php
@@ -99,7 +99,7 @@ class OpdsResponse
      */
     public function isUseForceExit(): bool
     {
-        return $this->forceExit;
+        return $this->forceExit ?? false;
     }
 
     /**

--- a/src/OpdsResponse.php
+++ b/src/OpdsResponse.php
@@ -15,6 +15,7 @@ class OpdsResponse
         protected bool $isXml = false,
         protected array $headers = [],
         protected ?string $contents = null,
+        protected ?bool $forceExit = null,
     ) {
     }
 
@@ -94,6 +95,14 @@ class OpdsResponse
     }
 
     /**
+     * To know if `exit` will be used after sending response.
+     */
+    public function isUseForceExit(): bool
+    {
+        return $this->forceExit;
+    }
+
+    /**
      * Get contents as array.
      *
      * @return array{
@@ -157,12 +166,26 @@ class OpdsResponse
     }
 
     /**
+     * Force `exit` after sending response.
+     */
+    public function forceExit(): self
+    {
+        $this->forceExit = true;
+
+        return $this;
+    }
+
+    /**
      * Send content to browser with correct header.
      *
      * @param  bool  $exit  To use `exit` after sending response.
      */
     public function send(bool $exit = false): string
     {
+        if ($this->forceExit !== null && $this->forceExit && ! $exit) {
+            $exit = true;
+        }
+
         foreach ($this->headers as $type => $value) {
             header($type.': '.$value);
         }

--- a/tests/OpdsConfigTest.php
+++ b/tests/OpdsConfigTest.php
@@ -27,7 +27,7 @@ it('can use setter', function () {
     expect($config->getPaginationQuery())->toBe('pagination');
     expect($config->getUpdated())->toBeInstanceOf(DateTime::class);
     expect($config->getMaxItemsPerPage())->toBe(10);
-    expect($config->isForceJson())->toBeTrue();
+    expect($config->isUseForceJson())->toBeTrue();
 });
 
 it('can use slug', function () {

--- a/tests/OpdsResponseTest.php
+++ b/tests/OpdsResponseTest.php
@@ -84,3 +84,28 @@ it('can failed on getJson', function () {
     expect($response->isJson())->toBeFalse();
     expect(fn () => $response->getJson())->toThrow(\Exception::class);
 });
+
+it('can use force exit', function () {
+    $html = '<!DOCTYPE html>';
+    $config = new OpdsConfig();
+    $config->forceExit();
+    $opds = Opds::make($config);
+
+    $engine = OpdsXmlEngine::make($opds);
+    $engine->setContents(['html' => $html]);
+
+    expect($engine->getContents())->toBe(['html' => $html]);
+
+    $response = $opds->getResponse();
+    expect($response->isUseForceExit())->toBeTrue();
+
+    $opds = Opds::make();
+
+    $engine = OpdsXmlEngine::make($opds);
+    $engine->setContents(['html' => $html]);
+
+    expect($engine->getContents())->toBe(['html' => $html]);
+
+    $response = $opds->getResponse();
+    expect($response->isUseForceExit())->toBeFalse();
+});


### PR DESCRIPTION
- `OpdsConfig::class`: `isForceJson()` is now `isUseForceJson()`, `forceExit` property allow to force `exit` on response sending, you can use constructor or `forceExit()` method to set it (default is `false`)
- `OpdsResponse::class`: `forceExit` property can be set with `forceExit()` method (default is `false), `send()` method can use `exit` parameter to override global `forceExit` property, of course if `OpdsConfig::class` `forceExit` property is `true` then `forceExit` will be true