### PR TITLE
v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ PHP package to create [OPDS feed](https://opds.io/) (Open Publication Distributi
 
 -   **Demo**: <https://bookshelves.ink/opds> from [`bookshelves-project/bookshelves`](https://github.com/bookshelves-project/bookshelves)
 
-| Version | Supported |       Date        | Format |  Query param   |
-| :-----: | :-------: | :---------------: | :----: | :------------: |
-|   1.2   |    ✅     | November 11, 2018 |  XML   | `?version=1.2` |
-|   2.0   |    ✅     |       Draft       |  JSON  | `?version=2.0` |
+| Version | Supported |       Date        | Format | Query param |
+| :-----: | :-------: | :---------------: | :----: | :---------: |
+|   1.2   |    ✅     | November 11, 2018 |  XML   |  `?v=1.2`   |
+|   2.0   |    ✅     |       Draft       |  JSON  |  `?v=2.0`   |
 
 All old versions: 0.9, 1.0 and 1.1 have a fallback to OPDS 1.2.
 
@@ -102,8 +102,8 @@ $opds = Opds::make()
 $opds->getConfig(); // OpdsConfig - Configuration used to create OPDS feed set into `make()` method
 $opds->getUrl(); // string|null - Current URL, generated automatically but can be overrided with `url()` method
 $opds->getTitle(); // string - Title of OPDS feed set with `title()` method
-$opds->getVersion(); // OpdsVersionEnum - OPDS version used, determined by query parameter `version` or `OpdsConfig::class` method `forceJson()`
-$opds->getQueryVersion(); // OpdsVersionEnum|null - Name of query parameter used to set OPDS version, default is `version`
+$opds->getVersion(); // OpdsVersionEnum - OPDS version used, determined by query parameter `v` or `OpdsConfig::class` method `forceJson()`
+$opds->getQueryVersion(); // OpdsVersionEnum|null - Name of query parameter used to set OPDS version, default is `v`
 $opds->getUrlParts(); // array - URL parts, determined from `url`
 $opds->getQuery(); // array - Query parameters, determined from `url`
 $opds->getFeeds(); // array - Feeds set with `feeds()` method
@@ -131,12 +131,12 @@ $opds->getResponse(); // OpdsResponse|null - Response of OPDS feed, will use `Op
 
 You can use query parameter `version` to set it dynamically. You could change this query into `OpdsConfig::class`.
 
--   Version `1.2` can be set with `?version=1.2`
--   Version `2.0` can be set with `?version=2.0`
+-   Version `1.2` can be set with `?v=1.2`
+-   Version `2.0` can be set with `?v=2.0`
 
 > [!WARNING]
 >
-> If you set `version` query parameter to `1.2` with `OpdsConfig::class` method `forceJson()`, query param will be ignored.
+> If you set `v` query parameter to `1.2` with `OpdsConfig::class` method `forceJson()`, query param will be ignored.
 
 ### OPDS Engine
 
@@ -266,7 +266,7 @@ $config = new OpdsConfig(
   iconUrl: 'https://example.com/icon.png', // Icon URL
   startUrl: 'https://example.com/opds', // Start URL, will be included in top navigation
   searchUrl: 'https://example.com/opds/search', // Search URL, will be included in top navigation
-  versionQuery: 'version', // query parameter for version
+  versionQuery: 'v', // query parameter for version
   paginationQuery: 'page', // query parameter for pagination
   updated: new DateTime(), // Last update of OPDS feed
   maxItemsPerPage: 16, // Max items per page, default is 16

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "kiwilan/php-opds",
   "description": "PHP package to create OPDS feed for eBooks.",
-  "version": "2.0.11",
+  "version": "2.1.0",
   "keywords": [
     "php",
     "ebook",

--- a/src/Engine/OpdsEngine.php
+++ b/src/Engine/OpdsEngine.php
@@ -18,8 +18,7 @@ abstract class OpdsEngine
         protected Opds $opds,
         protected OpdsPaginator|OpdsPaginate|null $paginator = null,
         protected array $contents = [],
-    ) {
-    }
+    ) {}
 
     /**
      * Create an instance of the converter.

--- a/src/Engine/Paginate/OpdsPagination.php
+++ b/src/Engine/Paginate/OpdsPagination.php
@@ -17,8 +17,7 @@ abstract class OpdsPagination
         protected int $perPage = 0,
         protected int $currentPage = 1,
         protected int $totalItems = 0,
-    ) {
-    }
+    ) {}
 
     protected function parseEngine(OpdsEngine $engine): self
     {

--- a/src/Entries/OpdsEntryBookAuthor.php
+++ b/src/Entries/OpdsEntryBookAuthor.php
@@ -7,8 +7,7 @@ class OpdsEntryBookAuthor extends OpdsEntry
     public function __construct(
         protected string $name,
         protected ?string $uri = null,
-    ) {
-    }
+    ) {}
 
     public function name(string $name): self
     {

--- a/src/Opds.php
+++ b/src/Opds.php
@@ -35,8 +35,7 @@ class Opds
         protected OpdsPaginator|OpdsPaginate|null $paginator = null,
         protected ?OpdsOutputEnum $output = null, // xml or json
         protected ?OpdsResponse $response = null,
-    ) {
-    }
+    ) {}
 
     /**
      * Create a new instance.
@@ -183,28 +182,34 @@ class Opds
         $this->query = $query;
 
         $version = $query[$this->config->getVersionQuery()] ?? null;
+        if ($version === null) {
+            $version = $query['version'] ?? null;
+        }
 
         if (! $version) {
             return $this;
         }
 
-        $enumVersion = match ($version) {
-            '0.9' => OpdsVersionEnum::v1Dot2,
-            '1.0' => OpdsVersionEnum::v1Dot2,
-            '1.1' => OpdsVersionEnum::v1Dot2,
-            '1.2' => OpdsVersionEnum::v1Dot2,
-            '2.0' => OpdsVersionEnum::v2Dot0,
-            default => null,
-        };
+        switch ($version) {
+            case str_starts_with($version, '0.'):
+                $enumVersion = OpdsVersionEnum::v1Dot2;
+                break;
 
-        if ($version !== null && $enumVersion === null) {
-            throw new \Exception("OPDS version {$version} is not supported.");
+            case str_starts_with($version, '1.'):
+                $enumVersion = OpdsVersionEnum::v1Dot2;
+                break;
+
+            case str_starts_with($version, '2.'):
+                $enumVersion = OpdsVersionEnum::v2Dot0;
+                break;
+
+            default:
+                $enumVersion = OpdsVersionEnum::v1Dot2;
+                break;
         }
 
-        if ($enumVersion) {
-            $this->queryVersion = $enumVersion;
-            $this->version = $this->queryVersion;
-        }
+        $this->queryVersion = $enumVersion;
+        $this->version = $this->queryVersion;
 
         return $this;
     }

--- a/src/OpdsConfig.php
+++ b/src/OpdsConfig.php
@@ -17,7 +17,7 @@ class OpdsConfig
      * @param  ?string  $iconUrl  Icon URL, for example: `https://example.com/favicon.ico`.
      * @param  ?string  $startUrl  Start URL, for example: `https://example.com/opds`.
      * @param  ?string  $searchUrl  Search URL, for example: `https://example.com/opds/search`.
-     * @param  string  $versionQuery  Version query, for example: `version`, default is `version`.
+     * @param  string  $versionQuery  Version query, for example: `v`, default is `v`.
      * @param  ?DateTime  $updated  Updated date, for example: `new DateTime()`.
      * @param  int  $maxItemsPerPage  Maximum items per page, default is `32`.
      * @param  bool  $forceJson  Force OPDS version 2.0 as default, default is `false`.
@@ -30,7 +30,7 @@ class OpdsConfig
         protected ?string $iconUrl = null,
         protected ?string $startUrl = null,
         protected ?string $searchUrl = null,
-        protected string $versionQuery = 'version',
+        protected string $versionQuery = 'v',
         protected string $paginationQuery = 'page',
         protected ?DateTime $updated = null,
         protected int $maxItemsPerPage = 16,

--- a/src/OpdsResponse.php
+++ b/src/OpdsResponse.php
@@ -16,8 +16,7 @@ class OpdsResponse
         protected array $headers = [],
         protected ?string $contents = null,
         protected ?bool $forceExit = null,
-    ) {
-    }
+    ) {}
 
     /**
      * Create a new Response.

--- a/tests/OpdsTest.php
+++ b/tests/OpdsTest.php
@@ -79,8 +79,8 @@ it('will throw exception with unspported version', function () {
     $opds = Opds::make()
         ->title('feed');
 
-    expect(fn () => $opds->url('http://localhost:8000/opds?version=0.8'))->toThrow(Exception::class);
-    expect(fn () => $opds->url('http://localhost:8000/opds?version=0.8'))->toThrow('OPDS version 0.8 is not supported.');
+    expect(fn () => $opds->url('http://localhost:8000/opds?version=0.8'))->not()->toThrow(Exception::class);
+    expect(fn () => $opds->url('http://localhost:8000/opds?version=0.8'))->not()->toThrow('OPDS version 0.8 is not supported.');
 });
 
 it('can use search', function () {


### PR DESCRIPTION
- OPDS version has now a fallback to existing version if an unknown version is provided
- OPDS version query parameter is now `v` instead of `version` (old parameter is still supported)