### PR TITLE
fix search query template

### DIFF
--- a/src/Engine/OpdsJsonEngine.php
+++ b/src/Engine/OpdsJsonEngine.php
@@ -45,7 +45,11 @@ class OpdsJsonEngine extends OpdsEngine
 
         if ($this->opds->getConfig()->getSearchUrl()) {
             $searchUrl = $this->route($this->opds->getConfig()->getSearchUrl());
-            $searchUrl .= '{&query}';
+            if (str_contains($searchUrl, '?')) {
+                $searchUrl .= '{&query}';
+            } else {
+                $searchUrl .= '{?query}';
+            }
 
             $this->contents['links'][] = $this->addJsonLink(rel: 'search', href: $searchUrl, attributes: ['templated' => true]);
         }


### PR DESCRIPTION
For search URLs like /opds/search the query template should be /opds/search(?query) instead of /opds/search(&query) - see https://drafts.opds.io/opds-2.0#3-search
